### PR TITLE
ignore deck/*.ydk and deck/private_*/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+
+*.ydk
+private_*/


### PR DESCRIPTION
## why

New users may already have some decks, or may have some private decks that are not suitable to commit to this repository. Therefore, it's necessary to ignore some files to deal with conflicts so that we can use this repository as the /deck dir of ygopro.

## how

We create a convention that `/deck/*.ydk` and `/deck/private_*/` of ygopro are private files. We should maintain those private decks in these paths.

## changes

Two extra lines in the `.gitignore`:

```
*.ydk
private_*/
```